### PR TITLE
Fixed incorrect psr-4 autoload path for DeskPRO namespace.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "DeskPRO\\": "src/"
+            "DeskPRO\\": "src/DeskPRO"
         }
     },
 


### PR DESCRIPTION
According to psr-4, as opposed to psr-0, [namespace prefix is not in the file path](https://getcomposer.org/doc/04-schema.md#psr-4). In other words, it should be mentioned in the path of the composer.json.
