### PR TITLE
Error on criteria's type for Organizations

### DIFF
--- a/src/DeskPRO/Service/Organization.php
+++ b/src/DeskPRO/Service/Organization.php
@@ -30,10 +30,10 @@ class Organization extends AbstractService
 	/**
 	 * Search for organization matching criteria
 	 * 
-	 * @param \DeskPRO\Criteria $criteria
+	 * @param \DeskPRO\Criteria\Organization $criteria
 	 * @return \DeskPRO\Api\Result Result Object
 	 */
-	public function find(\DeskPRO\Criteria $criteria)
+	public function find(\DeskPRO\Criteria\Organization $criteria)
 	{
 		return $this->call('GET', '/organizations', $criteria->toArray());
 	}


### PR DESCRIPTION
Hi,

When I try to find Organizations by criteria, I have an error due to the type of your param.
If I modify the \DeskPRO\Criteria param by a \DeskPRO\Criteria\Organization type, it works.

Can you fix it, please ?
Thanks.